### PR TITLE
Plot points faster

### DIFF
--- a/utils/graph.py
+++ b/utils/graph.py
@@ -18,7 +18,8 @@ def plot_solved(datas):
         solved_num = df.max()
         if isinstance(solved_num, float):
             solved_num = 0
-        df.plot(label="%s (%d)" % (username, solved_num))
+        df.plot(drawstyle="steps-post",
+                label="%s (%d)" % (username, solved_num))
     sns.set_style("whitegrid")
     plt.xlabel("Date")
     plt.ylabel("Problem Solved Count")
@@ -31,7 +32,8 @@ def plot_points(datas):
     plt.subplots()
     for username, data in datas.items():
         df = pd.Series(data)
-        df.plot(label="%s (%.2f)" % (username, df.max()))
+        df.plot(drawstyle="steps-post",
+                label="%s (%.2f)" % (username, df.max()))
     sns.set_style("whitegrid")
     plt.xlabel("Date")
     plt.ylabel("Points")


### PR DESCRIPTION
Improve the time complexity of `+plot points` from $O(N^2\log(N))$ (according to comment) to $O(N)$.

Speed comparison of `+plot points Xyene d zhouzixiang2004` with the bot running on my local machine:
Before: 7.15s
After: 5.74s
Iterating through the DB without doing anything (`continue` at line 202): 5.50s

Seems like DMOJ doesn't consider a partial AC as a solved problem in point calculation. Update the code to match DMOJ's result. The solved problem count by the code still deviates from the site's problem count for users like `Xyene` and I still don't know why.

Another change is eliminating the "linear interpolation" error in graph plotting.

Before:
![](https://cdn.discordapp.com/attachments/1059041956291948565/1059061799305093130/plot.png)

After:
![](https://cdn.discordapp.com/attachments/1059041956291948565/1059077462274879518/plot.png)